### PR TITLE
Bump dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "has-value": "^0.2.1",
+    "has-value": "^0.3.1",
     "isobject": "^2.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "has-value": "^0.3.1",
-    "isobject": "^2.0.0"
+    "isobject": "^3.0.0"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
For https://github.com/jonschlinkert/snapdragon/issues/6.
The `has-value` bump and the `isobject` bump are in separate commits; I can split this into two PR's if you would like.