### PR TITLE
Upgrade has-value

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "has-value": "^0.3.1",
+    "has-value": "^2.0.2",
     "isobject": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Micromatch is quite big because of duplicated dependecies. This will
allow to reduce amount of packages in micromatch.