### PR TITLE
Update isobject to latest version and required node 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,8 @@
-sudo: false
 os:
   - linux
   - osx
 language: node_js
 node_js:
-  - node
-  - '6'
-  - '4'
-  - '0.12'
-  - '0.10'
-matrix:
-  allow_failures:
-    - node_js: '4'
-    - node_js: '0.12'
-    - node_js: '0.10'
+  - 14
+  - 12
+  - 10

--- a/package.json
+++ b/package.json
@@ -18,14 +18,14 @@
   ],
   "main": "index.js",
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=10"
   },
   "scripts": {
     "test": "mocha"
   },
   "dependencies": {
     "has-value": "^2.0.2",
-    "isobject": "^3.0.0"
+    "isobject": "^4.0.0"
   },
   "devDependencies": {
     "gulp-format-md": "^0.1.11",


### PR DESCRIPTION
Node 10 is already required by has-value v2

BREAKING CHANGE: Require node 10 or newer