### PR TITLE
fix potential prototype pollution

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,16 @@
 var isObject = require('isobject');
 var has = require('has-value');
 
+const isUnsafeKey = key => {
+  return key === '__proto__' || key === 'constructor' || key === 'prototype';
+};
+
+const validateKey = key => {
+  if (isUnsafeKey(key)) {
+    throw new Error(`Cannot set unsafe key: "${key}"`);
+  }
+};
+
 module.exports = function unset(obj, prop) {
   if (!isObject(obj)) {
     throw new TypeError('expected an object.');
@@ -28,7 +38,11 @@ module.exports = function unset(obj, prop) {
     while (segs.length && segs[segs.length - 1].slice(-1) === '\\') {
       last = segs.pop().slice(0, -1) + '.' + last;
     }
-    while (segs.length) obj = obj[prop = segs.shift()];
+    while (segs.length) {
+      prop = segs.shift();
+      validateKey(prop);
+      obj = obj[prop];
+    }
     return (delete obj[last]);
   }
   return true;

--- a/test.js
+++ b/test.js
@@ -122,4 +122,11 @@ describe('input path as array paths', function () {
       unset();
     }).should.throw('expected an object.');
   });
+
+  it('should not allow unsetting unsafe values', () => {
+    assert.throws(() => unset({}, '__proto__.toString'));
+    assert.throws(() => unset(()=>{}, 'prototype'));
+    assert.throws(() => unset(()=>{}, 'contructor'));
+  });
+
 });


### PR DESCRIPTION
Following up on https://github.com/jonschlinkert/unset-value/issues/11, this PR aims to fix the Nexus IQ alerts.

Hopefully, it would fix this report: https://huntr.dev/bounties/1-npm-unset-value/
(the fix is heavily inspired by the code on your other repo [set-values](https://github.com/jonschlinkert/set-value/blob/master/index.js#L30))

Let me know if you have any comments!